### PR TITLE
Fix the parsing of gpu and memory clk/voltage table

### DIFF
--- a/daemon/src/gpu_controller.rs
+++ b/daemon/src/gpu_controller.rs
@@ -603,7 +603,6 @@ impl GpuController {
         let clock: i32 = line_parts[1].strip_suffix("MHZ").ok_or_else(|| GpuControllerError::ParseError)?.parse()?;
         let voltage: i32 = line_parts[2].strip_suffix("MV").ok_or_else(|| GpuControllerError::ParseError)?.parse()?;
 
-        println!("{} {} {}", num, clock, voltage);
         Ok((num, clock, voltage))
     }
 }


### PR DESCRIPTION
This fixes the panic on parsing gpu and memory clock/voltage table because apparently the casing of "MHz" and "mV" is not guaranteed.